### PR TITLE
💄 style: 슬라이드 모바일 퍼블리싱

### DIFF
--- a/src/components/Slide/index.tsx
+++ b/src/components/Slide/index.tsx
@@ -38,8 +38,10 @@ const Slide = ({ movies }: SlideProps) => {
         </Button>
       </Arrows>
       <SlideWrapper ref={slideRef}>
-        {movies?.map(({ id, large_cover_image, title }) => (
-          <PosterImage key={id} src={large_cover_image} alt={title} />
+        {movies.slice(0,15)?.map(({ id, large_cover_image, title }) => ( 
+          <PosterImageWrapper key={id}>
+            <PosterImage key={id} src={large_cover_image} alt={title} />
+          </PosterImageWrapper>
         ))}
       </SlideWrapper>
     </Container>
@@ -50,31 +52,39 @@ export default Slide;
 
 const Container = styled.div`
   background-color: ${({ theme }) => theme.color.background.indigo};
-  width: 100%;
   height: 100%;
   overflow: hidden;
   border-radius: 4px;
   padding: 20px 10px 20px 10px;
+  ${({ theme }) => theme.media.mobile`
+    position: relative;
+    width: clac(100vw - 20px);
+    height: calc(100vh - 40px);
+    max-height: calc(400px + 2em);
+    overflow-x: scroll;
+    scroll-behavior: smooth;
+  `};
 `;
 
 const Arrows = styled.div`
   display: flex;
   justify-content: flex-end;
   column-gap: 10px;
-  margin-bottom: 3em;
   svg {
     width: 30px;
     border-radius: 10px;
     cursor: pointer;
     color: #abacb4;
   }
+  ${({ theme }) => theme.media.mobile`
+    display: none;
+  `};
 `;
 
 const Button = styled.button`
   padding: 0;
   border-radius: 4px;
   background-color: ${({ theme }) => theme.color.background.darkgray};
-
   &:hover {
     opacity: 0.6;
   }
@@ -83,21 +93,37 @@ const Button = styled.button`
 const SlideWrapper = styled.div`
   height: 330px;
   max-width: 250px;
+  width: 100%;
   display: flex;
   align-items: center;
   column-gap: 10px;
-  margin-bottom: 2em;
+  margin: 3em 0;
+  ${({ theme }) => theme.media.mobile`
+    position: absolute;
+    margin: auto;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  `};
+`;
+
+const PosterImageWrapper = styled.div`
+  width: 250px;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  transition: 0.2s;
+  &:hover {
+    height: 400px;
+  }
 `;
 
 const PosterImage = styled.img`
-  width: 100%;
   height: 100%;
-  object-fit: contain;
+  object-fit: cover;
   transition: 0.2s;
   cursor: pointer;
   &:hover {
     border: 5px solid ${({ theme }) => theme.color.border.lightblue};
-    object-fit: cover;
-    height: 400px;
   }
 `;

--- a/src/hooks/useSlide.ts
+++ b/src/hooks/useSlide.ts
@@ -6,7 +6,7 @@ const useSlide = (slideRef: RefObject<HTMLDivElement>) => {
 
   useEffect(() => {
     const slide = slideRef.current;
-    if (!slide) return;
+    if (!slide || window.innerWidth <= 600) return;
 
     slide.style.transition = 'all 0.5s ease-in-out';
     slide.style.transform = `translateX(-${currentSlide}00%)`;


### PR DESCRIPTION
## 😲 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
<!-- [] 안에 소문자 엑스(x)를 넣으면 체크표시가 활성화됩니다! ex) [x] -->
- [ ] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

## 😎 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
<!-- 메인 페이지의 lazy loading을 ~을 이용하여 구현하였다. 등의 이야기를 작성해주세요 :) -->
[screen-recording.webm](https://user-images.githubusercontent.com/84497426/178431837-e585ce85-7217-464f-83b9-10b1fc12f883.webm)
- 슬라이드 모바일 퍼블리싱
  - scroll-snap을 이용하여 부드럽고 한 번의 슬라이드에 포스터의 중간에 끝나도록 구현하고자 했음. 미완성.
  - hook에서 translate 속성을 mobile 화면에선 작동하지 않게 함.

## 🥳 성장 포인트 (기능 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
<!-- Hook의 중요성을 다시금 깨닫게 되었다 등의 사소한 내용까지도! 편하게 작성해주세요 XD -->

## 🤔 기타 질문 및 특이 사항
<!-- @@ 부분 코드가 너무 복잡한 것 같은데 더 줄일 수 있는 방법이 없을까요? 같은 고민되는 내용을 마구 공유해주세요! -->
- 가장 힘들었던 것은, 이미지를 width=100%인 div에 담으면 둘 다 width가 0이 되어버리는 현상을 고치지 못하여 직접 width 값을 px로 주는 방식을 택함. 모바일에서 한 포스터씩 가운데에 두어서 슬라이드하기 쉽게 하고자 둠.
![image](https://user-images.githubusercontent.com/84497426/178433026-a374689a-2d7f-40df-9ddd-2021e6114dce.png)
![image](https://user-images.githubusercontent.com/84497426/178432767-6b8077b8-7945-4ca9-a932-5136a33fc105.png)